### PR TITLE
fixed autoconf error

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,6 @@ if test "$debug_on" = "no"; then
         AC_DEFINE([NDEBUG],, [Define to drop debug support])
 fi
 AM_CONDITIONAL(DEBUG, test "$debug_on" = yes)
+AM_PROG_CC_C_O
 
 AC_OUTPUT
-


### PR DESCRIPTION
Makefile.am:2: warning: compiling 'archivemount.c' with per-target flags requires 'AM_PROG_CC_C_O' in
'configure.ac'

Also, I'm wondering why there are different commits in http://www.cybernoia.de/software/archivemount/git ?
